### PR TITLE
Translate gRPC codes to HTTP codes

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -20,13 +20,13 @@ type accountsHandler struct {
 func (h *accountsHandler) Authenticate(c *gin.Context) {
 	body := &accountsv1.AuthenticateRequest{}
 	if err := c.ShouldBindJSON(body); err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
 	res, err := h.accountsClient.Authenticate(context.Background(), body)
 	if err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -36,13 +36,13 @@ func (h *accountsHandler) Authenticate(c *gin.Context) {
 func (h *accountsHandler) Create(c *gin.Context) {
 	body := &accountsv1.CreateAccountRequest{}
 	if err := c.ShouldBindJSON(body); err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
 	res, err := h.accountsClient.CreateAccount(context.Background(), body)
 	if err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -52,7 +52,7 @@ func (h *accountsHandler) Create(c *gin.Context) {
 func (h *accountsHandler) Get(c *gin.Context) {
 	bearer, err := h.authenticate(c)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, httpError{Error: err.Error()})
+		writeError(c, http.StatusUnauthorized, err)
 		return
 	}
 
@@ -62,7 +62,7 @@ func (h *accountsHandler) Get(c *gin.Context) {
 
 	res, err := h.accountsClient.GetAccount(contextWithGrpcBearer(context.Background(), bearer), body)
 	if err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -76,7 +76,7 @@ func (h *accountsHandler) List(c *gin.Context) {
 func (h *accountsHandler) Update(c *gin.Context) {
 	bearer, err := h.authenticate(c)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, httpError{Error: err.Error()})
+		writeError(c, http.StatusUnauthorized, err)
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h *accountsHandler) Update(c *gin.Context) {
 
 	res, err := h.accountsClient.UpdateAccount(contextWithGrpcBearer(context.Background(), bearer), body)
 	if err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -99,7 +99,7 @@ func (h *accountsHandler) Update(c *gin.Context) {
 func (h *accountsHandler) Delete(c *gin.Context) {
 	bearer, err := h.authenticate(c)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, httpError{Error: err.Error()})
+		writeError(c, http.StatusUnauthorized, err)
 		return
 	}
 
@@ -109,7 +109,7 @@ func (h *accountsHandler) Delete(c *gin.Context) {
 
 	res, err := h.accountsClient.DeleteAccount(contextWithGrpcBearer(context.Background(), bearer), body)
 	if err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/groups.go
+++ b/groups.go
@@ -15,13 +15,13 @@ type groupsHandler struct {
 func (h *groupsHandler) Create(c *gin.Context) {
 	body := &accountsv1.CreateGroupRequest{}
 	if err := c.ShouldBindJSON(body); err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
 	res, err := h.groupsClient.CreateGroup(context.Background(), body)
 	if err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -35,7 +35,7 @@ func (h *groupsHandler) Delete(c *gin.Context) {
 
 	res, err := h.groupsClient.DeleteGroup(context.Background(), body)
 	if err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/recommendations.go
+++ b/recommendations.go
@@ -15,13 +15,13 @@ type recommendationsHandler struct {
 func (h *recommendationsHandler) Get(c *gin.Context) {
 	body := &recommendationsv1.ExtractKeywordsRequest{}
 	if err := c.ShouldBindJSON(body); err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
 	res, err := h.recommendationsClient.ExtractKeywords(context.Background(), body)
 	if err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"context"
+	"net/http"
 
+	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -11,8 +15,44 @@ var (
 	grpcAuthorizationHeader = "authorization"
 )
 
+var grpcCodeToHttpCode = map[codes.Code]int{
+	codes.OK:                 http.StatusOK,
+	codes.Canceled:           http.StatusInternalServerError,
+	codes.Unknown:            http.StatusInternalServerError,
+	codes.InvalidArgument:    http.StatusBadRequest,
+	codes.DeadlineExceeded:   http.StatusRequestTimeout,
+	codes.NotFound:           http.StatusNotFound,
+	codes.AlreadyExists:      http.StatusConflict,
+	codes.PermissionDenied:   http.StatusUnauthorized,
+	codes.ResourceExhausted:  http.StatusServiceUnavailable,
+	codes.FailedPrecondition: http.StatusFailedDependency,
+	codes.Aborted:            http.StatusServiceUnavailable,
+	codes.OutOfRange:         http.StatusRequestedRangeNotSatisfiable,
+	codes.Unimplemented:      http.StatusNotImplemented,
+	codes.Internal:           http.StatusInternalServerError,
+	codes.Unavailable:        http.StatusServiceUnavailable,
+	codes.DataLoss:           http.StatusInternalServerError,
+	codes.Unauthenticated:    http.StatusUnauthorized,
+}
+
 // contextWithGrpcBearer returns a copy of the parent context with
 // outgoing authorization metadata attached.
 func contextWithGrpcBearer(parent context.Context, bearer string) context.Context {
 	return metadata.AppendToOutgoingContext(parent, grpcAuthorizationHeader, bearer)
+}
+
+// writeError writes to the body of an http request the error passed as
+// argument. If the error is a gRPC error, the status code written will
+// depend on the gRPC status code.
+func writeError(c *gin.Context, code int, err error) {
+	s, ok := status.FromError(err)
+	if ok {
+		translatedCode := grpcCodeToHttpCode[s.Code()]
+		if translatedCode == 0 {
+			translatedCode = http.StatusInternalServerError
+		}
+		c.JSON(translatedCode, httpError{Error: s.Message()})
+		return
+	}
+	c.JSON(code, httpError{Error: err.Error()})
 }


### PR DESCRIPTION
#### Description

This PR introduces a mapping between the status codes of the gRPC framework (`Unavailable`, `FailedPrecondition`, etc) and the status codes of the HTTP protocol (`400 Bad Request`, `201 Created`, etc).

Updates #7

#### Changelog

- [ENHANCEMENT] Translate gRPC status codes into HTTP status codes.
