### PR TITLE
Fix `/recommendations/keywords` endpoint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -264,4 +264,20 @@ The endpoints requiring authentication are marked with the tag `AuthRequired`.
 {}
 ```
 
+### Extract Keywords
 
+**Endpoint:** `POST /recommendations/keywords`
+
+**Body:**
+```json
+{
+    "content": "string"
+}
+```
+
+**Response:**
+```json
+{
+    "keywords": ["strings"]
+}
+```

--- a/main.go
+++ b/main.go
@@ -38,13 +38,13 @@ func main() {
 	s.Engine.PATCH("/accounts/:id", s.accountsHandler.Update)
 	s.Engine.DELETE("/accounts/:id", s.accountsHandler.Delete)
 
-	s.Engine.GET("/recommendations/keywords", s.recommendationsHandler.Get)
-
 	s.Engine.POST("/groups", s.groupsHandler.Create)
 	s.Engine.POST("/groups/:id/join", s.groupsHandler.Join)
 	s.Engine.DELETE("/groups/:id", s.groupsHandler.Delete)
 	s.Engine.PATCH("/groups/:id", s.groupsHandler.Update)
 	s.Engine.GET("/groups/:id/members", s.groupsHandler.ListMembers)
+
+	s.Engine.POST("/recommendations/keywords", s.recommendationsHandler.ExtractKeywords)
 
 	s.Run()
 	defer s.Close()

--- a/recommendations.go
+++ b/recommendations.go
@@ -12,7 +12,7 @@ type recommendationsHandler struct {
 	recommendationsClient recommendationsv1.RecommendationsAPIClient
 }
 
-func (h *recommendationsHandler) Get(c *gin.Context) {
+func (h *recommendationsHandler) ExtractKeywords(c *gin.Context) {
 	body := &recommendationsv1.ExtractKeywordsRequest{}
 	if err := c.ShouldBindJSON(body); err != nil {
 		writeError(c, http.StatusBadRequest, err)


### PR DESCRIPTION
#### Description

N/A

#### Changelog

- [BUGFIX] Extract keywords endpoint was `GET` instead of `POST`.
- [DOCS] Document extract keywords endpoint.
