### PR TITLE
Add `/groups` and `/invites` endpoints

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -4,7 +4,6 @@ import (
 	accountsv1 "api-gateway/protorepo/noted/accounts/v1"
 	"context"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 )
@@ -56,22 +55,11 @@ func (h *accountsHandler) ListAccounts(c *gin.Context) {
 		return
 	}
 
-	offset, err := strconv.ParseInt(c.Query("offset"), 10, 32)
-	if err != nil {
-		writeError(c, http.StatusBadRequest, err)
-		return
-	}
-
-	limit, err := strconv.ParseInt(c.Query("limit"), 10, 32)
-	if err != nil {
-		writeError(c, http.StatusBadRequest, err)
-		return
-	}
-
 	body := &accountsv1.ListAccountsRequest{
-		Limit:  int32(limit),
-		Offset: int32(offset),
+		Limit:  queryAsInt32OrDefault(c, "limit", 0),
+		Offset: queryAsInt32OrDefault(c, "offset", 0),
 	}
+
 	res, err := h.accountsClient.ListAccounts(contextWithGrpcBearer(context.Background(), bearer), body)
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, err)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,16 @@ This document describes all the endpoints of the Noted API gateway and their exp
       - [Update Group](#update-group)
       - [Delete Group](#delete-group)
       - [List Groups](#list-groups)
+      - [Get Group Member](#get-group-member)
+      - [Update Group Member](#update-group-member)
+      - [Remove Group Member](#remove-group-member)
+      - [List Group Members](#list-group-members)
+      - [Add Group Note](#add-group-note)
+      - [Get Group Note](#get-group-note)
+      - [Update Group Note](#update-group-note)
+      - [Remove Group Note](#remove-group-note)
+      - [List Group Notes](#list-group-notes)
     - [Invites](#invites)
-    - [Notes](#notes)
     - [Recommendations](#recommendations)
       - [Extract Keywords](#extract-keywords)
 
@@ -153,8 +161,8 @@ This API enforces authorization. For example, you cannot modify a group you're n
 **Tags:** `InternalToken`
 
 **Query:**
-- `offset=<int32>`: integer cursor.
-- `limit=<int32>`: maximum number of objects returned.
+- `offset=<int32>`: (Optional) integer cursor.
+- `limit=<int32>`: (Optional) maximum number of objects returned.
 
 **Response:**
 ```json
@@ -269,15 +277,16 @@ This API enforces authorization. For example, you cannot modify a group you're n
 
 #### List Groups
 
-**Description:** Must be groups member.
+**Description:** Must be group member.
 
 **Endpoint:** `GET /groups`
 
 **Tags:** `AuthRequired`
 
 **Query:**
-- `offset=<int32>`: integer cursor.
-- `limit=<int32>`: maximum number of objects returned.
+- `account_id=<string>`: list groups of account.
+- `offset=<int32>`: (Optional) integer cursor.
+- `limit=<int32>`: (Optional) maximum number of objects returned.
 
 **Response:**
 ```json
@@ -293,9 +302,249 @@ This API enforces authorization. For example, you cannot modify a group you're n
 }
 ```
 
-### Invites
+#### Get Group Member
 
-### Notes
+**Description:** Must be group member.
+
+**Endpoint:** `GET /groups/:group_id/members/:member_id`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `group_id`: UUID of the group.
+- `member_id`: UUID of the account.
+
+**Response:**
+```json
+{
+    "member": {
+        "account_id": "string",
+        "role": "string",
+        "created_at": "string"
+    }
+}
+```
+
+#### Update Group Member
+
+**Description**: Must be group administrator.
+
+**Endpoint:** `PATCH /groups/:group_id/members/:member_id`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `group_id`: UUID of the group.
+- `member_id`: UUID of the account.
+
+**Body:**
+```json
+{
+    "member": {
+        "role": "string",
+    },
+    "update_mask": ["role"]
+}
+```
+
+**Response:**
+```json
+{
+    "member": {
+        "account_id": "string",
+        "role": "string",
+        "created_at": "string"
+    }
+}
+```
+
+#### Remove Group Member
+
+**Description:** Must be group administrator or the authenticated user removing itself from the group.
+
+**Endpoint:** `DELETE /groups/:group_id/members/:member_id`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `group_id`: UUID of the group.
+- `member_id`: UUID of the account.
+
+**Response:**
+```json
+{}
+```
+
+#### List Group Members
+
+**Description:** Must be group member.
+
+**Endpoint:** `GET /groups/:group_id/members`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `group_id`: UUID of the group.
+
+**Query:**
+- `offset=<int32>`: (Optional) integer cursor.
+- `limit=<int32>`: (Optional) maximum number of objects returned.
+
+**Response:**
+```json
+{
+    "members": [
+        {
+            "account_id": "string",
+            "role": "string",
+            "created_at": "string",
+        }
+    ]
+}
+```
+
+#### Add Group Note
+
+**Description:** Must be group member and author of the note.
+
+**Endpoint:** `POST /groups/:group_id/notes`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `group_id`: UUID of the group.
+
+**Body:**
+```json
+{
+    "group_id": "string",
+    "note_id": "string",
+    "title": "string",
+    "author_account_id": "string",
+    "folder_id": "string"
+}
+```
+
+**Response:**
+```json
+{
+    "note": {
+        "note_id": "string",
+        "title": "string",
+        "author_account_id": "string",
+        "folder_id": "string"
+    }
+}
+```
+
+#### Get Group Note
+
+**Description:** Must be group member.
+
+**Endpoint:** `GET /groups/:group_id/notes/:note_id`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `group_id`: UUID of the group.
+- `note_id`: UUID of the group note.
+
+**Response:**
+```json
+{
+    "note": {
+        "note_id": "string",
+        "title": "string",
+        "author_account_id": "string",
+        "folder_id": "string"
+    }
+}
+```
+
+#### Update Group Note
+
+**Description:** Must be group member. Can only update `note.title` and `note.folder_id`.
+
+**Endpoint:** `PATCH /groups/:group_id/notes/:note_id`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `group_id`: UUID of the group.
+- `note_id`: UUID of the group note.
+
+**Body:**
+```json
+{
+    "note": {
+        "title": "string",
+        "folder_id": "string"
+    },
+    "update_mask": ["title", "folder_id"]
+}
+```
+
+**Response:**
+```json
+{
+    "note": {
+        "note_id": "string",
+        "title": "string",
+        "author_account_id": "string",
+        "folder_id": "string"
+    }
+}
+```
+
+#### Remove Group Note
+
+**Description:** Must be group member, author of the note or administrator.
+
+**Endpoint:** `DELETE /groups/:group_id/notes/:note_id`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `group_id`: UUID of the group.
+- `note_id`: UUID of the group note.
+
+**Response:**
+```json
+{}
+```
+
+#### List Group Notes
+
+**Description:** Must be group member.
+
+**Endpoint:** `GET /groups/:group_id/notes`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `group_id`: UUID of the group.
+
+**Query:**
+- `offset=<int32>`: (Optional) integer cursor.
+- `limit=<int32>`: (Optional) maximum number of objects returned.
+- `author_account_id=<string>`: (Optional) List only notes from that account.
+- `folder_id=<string>`: (Optional) coming soon.
+
+**Response:**
+```json
+{
+    "notes": [
+        {
+            "note_id": "string",
+            "title": "string",
+            "author_account_id": "string",
+            "folder_id": "string"
+        }
+    ]
+}
+```
+
+### Invites
 
 ### Recommendations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,11 @@ This document describes all the endpoints of the Noted API gateway and their exp
       - [Remove Group Note](#remove-group-note)
       - [List Group Notes](#list-group-notes)
     - [Invites](#invites)
+      - [Send Invite](#send-invite)
+      - [Get Invite](#get-invite)
+      - [Accept Invite](#accept-invite)
+      - [Deny Invite](#deny-invite)
+      - [List Invites](#list-invites)
     - [Recommendations](#recommendations)
       - [Extract Keywords](#extract-keywords)
 
@@ -161,8 +166,8 @@ This API enforces authorization. For example, you cannot modify a group you're n
 **Tags:** `InternalToken`
 
 **Query:**
-- `offset=<int32>`: (Optional) integer cursor.
-- `limit=<int32>`: (Optional) maximum number of objects returned.
+- `offset=<int32>`: (Optional) Integer cursor.
+- `limit=<int32>`: (Optional) Maximum number of objects returned.
 
 **Response:**
 ```json
@@ -285,8 +290,8 @@ This API enforces authorization. For example, you cannot modify a group you're n
 
 **Query:**
 - `account_id=<string>`: list groups of account.
-- `offset=<int32>`: (Optional) integer cursor.
-- `limit=<int32>`: (Optional) maximum number of objects returned.
+- `offset=<int32>`: (Optional) Integer cursor.
+- `limit=<int32>`: (Optional) Maximum number of objects returned.
 
 **Response:**
 ```json
@@ -387,8 +392,8 @@ This API enforces authorization. For example, you cannot modify a group you're n
 - `group_id`: UUID of the group.
 
 **Query:**
-- `offset=<int32>`: (Optional) integer cursor.
-- `limit=<int32>`: (Optional) maximum number of objects returned.
+- `offset=<int32>`: (Optional) Integer cursor.
+- `limit=<int32>`: (Optional) Maximum number of objects returned.
 
 **Response:**
 ```json
@@ -525,8 +530,8 @@ This API enforces authorization. For example, you cannot modify a group you're n
 - `group_id`: UUID of the group.
 
 **Query:**
-- `offset=<int32>`: (Optional) integer cursor.
-- `limit=<int32>`: (Optional) maximum number of objects returned.
+- `offset=<int32>`: (Optional) Integer cursor.
+- `limit=<int32>`: (Optional) Maximum number of objects returned.
 - `author_account_id=<string>`: (Optional) List only notes from that account.
 - `folder_id=<string>`: (Optional) coming soon.
 
@@ -545,6 +550,116 @@ This API enforces authorization. For example, you cannot modify a group you're n
 ```
 
 ### Invites
+
+#### Send Invite
+
+**Description:** The sender defaults to the authenticated user. Must be group member.
+
+**Endpoint:** `POST /invites`
+
+**Body:**
+```json
+{
+    "group_id": "string",
+    "recipient_account_id": "string"
+}
+```
+
+**Response:**
+```json
+{
+    "invite": {
+        "id": "string",
+        "group_id": "string",
+        "sender_account_id": "string",
+        "recipient_account_id": "string"
+    }
+}
+```
+
+#### Get Invite
+
+**Description:** Must be group administrator or sender or recipient.
+
+**Endpoint:** `GET /invites/:invite_id`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `invite_id`: UUID of the invite.
+
+**Response:**
+```json
+{
+    "invite": {
+        "id": "string",
+        "group_id": "string",
+        "sender_account_id": "string",
+        "recipient_account_id": "string"
+    }
+}
+```
+
+#### Accept Invite
+
+**Description:** Must be recipient. Accepting an invitation automatically adds the recipient to the group and deletes the invite.
+
+**Endpoint:** `POST /invites/:invite_id/accept`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `invite_id`: UUID of the invite.
+
+**Response:**
+```json
+{}
+```
+
+#### Deny Invite
+
+**Description:** Must be recipient. Deletes the invitation without making the recipient join the group.
+
+**Endpoint:** `POST /invites/:invite_id/deny`
+
+**Tags:** `AuthRequired`
+
+**Path:**
+- `invite_id`: UUID of the invite.
+
+**Response:**
+```json
+{}
+```
+
+#### List Invites
+
+**Description:** Must be group administrator or sender or recipient.
+
+**Endpoint:** `GET /invites`
+
+**Tags:** `AuthRequired`
+
+**Query:**
+- `sender_account_id=<string>`: (Optional) Returns only invites from sender.
+- `recipient_account_id=<string>`: (Optional) Returns only invites destined to recipient.
+- `group_id=<string>`: (Optional) Returns only invites for a given group.
+- `offset=<int32>`: (Optional) Integer cursor.
+- `limit=<int32>`: (Optional) Maximum number of objects returned.
+
+**Response:**
+```json
+{
+    "invites": [
+        {
+            "id": "string",
+            "group_id": "string",
+            "sender_account_id": "string",
+            "recipient_account_id": "string"
+        }
+    ]
+}
+```
 
 ### Recommendations
 

--- a/groups.go
+++ b/groups.go
@@ -106,9 +106,219 @@ func (h *groupsHandler) ListGroups(c *gin.Context) {
 
 	body := &accountsv1.ListGroupsRequest{
 		AccountId: c.Query("account_id"),
+		Limit:     queryAsInt32OrDefault(c, "limit", 0),
+		Offset:    queryAsInt32OrDefault(c, "offset", 0),
 	}
 
 	res, err := h.groupsClient.ListGroups(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *groupsHandler) GetGroupMember(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.GetGroupMemberRequest{
+		GroupId:   c.Param("group_id"),
+		AccountId: c.Param("member_id"),
+	}
+
+	res, err := h.groupsClient.GetGroupMember(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *groupsHandler) UpdateGroupMember(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.UpdateGroupMemberRequest{
+		Member: &accountsv1.GroupMember{},
+	}
+	if err := c.ShouldBindJSON(body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	body.GroupId = c.Param("group_id")
+	body.Member.AccountId = c.Param("member_id")
+
+	res, err := h.groupsClient.UpdateGroupMember(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *groupsHandler) RemoveGroupMember(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.RemoveGroupMemberRequest{
+		GroupId:   c.Param("group_id"),
+		AccountId: c.Param("member_id"),
+	}
+
+	res, err := h.groupsClient.RemoveGroupMember(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *groupsHandler) ListGroupMembers(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.ListGroupMembersRequest{
+		GroupId: c.Param("group_id"),
+		Limit:   queryAsInt32OrDefault(c, "limit", 0),
+		Offset:  queryAsInt32OrDefault(c, "offset", 0),
+	}
+
+	res, err := h.groupsClient.ListGroupMembers(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *groupsHandler) AddGroupNote(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.AddGroupNoteRequest{}
+	if err := c.ShouldBindJSON(body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	body.GroupId = c.Param("group_id")
+
+	res, err := h.groupsClient.AddGroupNote(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *groupsHandler) GetGroupNote(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.GetGroupNoteRequest{
+		GroupId: c.Param("group_id"),
+		NoteId:  c.Param("note_id"),
+	}
+
+	res, err := h.groupsClient.GetGroupNote(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *groupsHandler) UpdateGroupNote(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.UpdateGroupNoteRequest{
+		Note: &accountsv1.GroupNote{},
+	}
+	if err := c.ShouldBindJSON(body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	body.GroupId = c.Param("group_id")
+	body.Note.NoteId = c.Param("note_id")
+
+	res, err := h.groupsClient.UpdateGroupNote(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *groupsHandler) RemoveGroupNote(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.RemoveGroupNoteRequest{
+		GroupId: c.Param("group_id"),
+		NoteId:  c.Param("note_id"),
+	}
+
+	res, err := h.groupsClient.RemoveGroupNote(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *groupsHandler) ListGroupNotes(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.ListGroupNotesRequest{
+		GroupId:         c.Param("group_id"),
+		AuthorAccountId: c.Query("author_account_id"),
+		FolderId:        c.Query("folder_id"),
+		Limit:           queryAsInt32OrDefault(c, "limit", 0),
+		Offset:          queryAsInt32OrDefault(c, "offset", 0),
+	}
+
+	res, err := h.groupsClient.ListGroupNotes(contextWithGrpcBearer(context.Background(), bearer), body)
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, err)
 		return

--- a/invites.go
+++ b/invites.go
@@ -1,0 +1,1 @@
+package main

--- a/invites.go
+++ b/invites.go
@@ -1,1 +1,119 @@
 package main
+
+import (
+	accountsv1 "api-gateway/protorepo/noted/accounts/v1"
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type invitesHandler struct {
+	invitesClient accountsv1.InvitesAPIClient
+}
+
+func (h *invitesHandler) SendInvite(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.SendInviteRequest{}
+	if err := c.ShouldBindJSON(body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	res, err := h.invitesClient.SendInvite(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *invitesHandler) GetInvite(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.GetInviteRequest{
+		InviteId: c.Param("invite_id"),
+	}
+
+	res, err := h.invitesClient.GetInvite(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *invitesHandler) AcceptInvite(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.AcceptInviteRequest{
+		InviteId: c.Param("invite_id"),
+	}
+
+	res, err := h.invitesClient.AcceptInvite(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *invitesHandler) DenyInvite(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.DenyInviteRequest{
+		InviteId: c.Param("invite_id"),
+	}
+
+	res, err := h.invitesClient.DenyInvite(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *invitesHandler) ListInvites(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &accountsv1.ListInvitesRequest{
+		SenderAccountId:    c.Query("sender_account_id"),
+		RecipientAccountId: c.Query("recipient_account_id"),
+		GroupId:            c.Query("group_id"),
+		Limit:              queryAsInt32OrDefault(c, "limit", 0),
+		Offset:             queryAsInt32OrDefault(c, "limit", 0),
+	}
+
+	res, err := h.invitesClient.ListInvites(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}

--- a/main.go
+++ b/main.go
@@ -59,12 +59,12 @@ func main() {
 	s.Engine.DELETE("/groups/:group_id/notes/:note_id", s.groupsHandler.RemoveGroupNote)
 	s.Engine.GET("/groups/:group_id/notes", s.groupsHandler.ListGroupNotes)
 
-	// // Invites
-	// s.Engine.POST("/invites", s.invitesHandler.SendInvite)
-	// s.Engine.GET("/invites/:invite_id", s.invitesHandler.GetInvite)
-	// s.Engine.POST("/invites/:invite_id/accept", s.invitesHandler.AcceptInvite)
-	// s.Engine.POST("/invites/:invite_id/deny", s.invitesHandler.DenyInvite)
-	// s.Engine.GET("/invites", s.invitesHandler.ListInvites)
+	// Invites
+	s.Engine.POST("/invites", s.invitesHandler.SendInvite)
+	s.Engine.GET("/invites/:invite_id", s.invitesHandler.GetInvite)
+	s.Engine.POST("/invites/:invite_id/accept", s.invitesHandler.AcceptInvite)
+	s.Engine.POST("/invites/:invite_id/deny", s.invitesHandler.DenyInvite)
+	s.Engine.GET("/invites", s.invitesHandler.ListInvites)
 
 	// Recommendations
 	s.Engine.POST("/recommendations/keywords", s.recommendationsHandler.ExtractKeywords)

--- a/main.go
+++ b/main.go
@@ -31,19 +31,42 @@ func main() {
 	s.Engine.Use(s.AccessControlMiddleware)
 	s.Engine.Use(s.PreflightMiddleware)
 
+	// Accounts
+	s.Engine.POST("/accounts", s.accountsHandler.CreateAccount)
+	s.Engine.GET("/accounts/:account_id", s.accountsHandler.GetAccount)
+	s.Engine.PATCH("/accounts/:account_id", s.accountsHandler.UpdateAccount)
+	s.Engine.DELETE("/accounts/:account_id", s.accountsHandler.DeleteAccount)
+	s.Engine.GET("/accounts", s.accountsHandler.ListAccounts)
 	s.Engine.POST("/authenticate", s.accountsHandler.Authenticate)
-	s.Engine.GET("/accounts", s.accountsHandler.List)
-	s.Engine.GET("/accounts/:id", s.accountsHandler.Get)
-	s.Engine.POST("/accounts", s.accountsHandler.Create)
-	s.Engine.PATCH("/accounts/:id", s.accountsHandler.Update)
-	s.Engine.DELETE("/accounts/:id", s.accountsHandler.Delete)
 
-	s.Engine.POST("/groups", s.groupsHandler.Create)
-	s.Engine.POST("/groups/:id/join", s.groupsHandler.Join)
-	s.Engine.DELETE("/groups/:id", s.groupsHandler.Delete)
-	s.Engine.PATCH("/groups/:id", s.groupsHandler.Update)
-	s.Engine.GET("/groups/:id/members", s.groupsHandler.ListMembers)
+	// Groups
+	s.Engine.POST("/groups", s.groupsHandler.CreateGroup)
+	s.Engine.GET("/groups/:group_id", s.groupsHandler.GetGroup)
+	s.Engine.PATCH("/groups/:group_id", s.groupsHandler.UpdateGroup)
+	s.Engine.DELETE("/groups/:group_id", s.groupsHandler.DeleteGroup)
+	s.Engine.GET("/groups", s.groupsHandler.ListGroups)
 
+	// // Group Members
+	// s.Engine.GET("/groups/:group_id/members/:member_id", s.groupsHandler.GetGroupMember)
+	// s.Engine.PATCH("/groups/:group_id/members/:member_id", s.groupsHandler.UpdateGroupMember)
+	// s.Engine.DELETE("/groups/:group_id/members/:member_id", s.groupsHandler.RemoveGroupMember)
+	// s.Engine.GET("/groups/:group_id/members", s.groupsHandler.ListGroupMembers)
+
+	// // Group Notes
+	// s.Engine.POST("/groups/:group_id/notes", s.groupsHandler.AddGroupNote)
+	// s.Engine.GET("/groups/:group_id/notes/:note_id", s.groupsHandler.GetGroupNote)
+	// s.Engine.PATCH("/groups/:group_id/notes/:note_id", s.groupsHandler.UpdateGroupNote)
+	// s.Engine.DELETE("/groups/:group_id/notes/:note_id", s.groupsHandler.RemoveGroupNote)
+	// s.Engine.GET("/groups/:group_id/notes", s.groupsHandler.ListGroupNotes)
+
+	// // Invites
+	// s.Engine.POST("/invites", s.invitesHandler.SendInvite)
+	// s.Engine.GET("/invites/:invite_id", s.invitesHandler.GetInvite)
+	// s.Engine.POST("/invites/:invite_id/accept", s.invitesHandler.AcceptInvite)
+	// s.Engine.POST("/invites/:invite_id/deny", s.invitesHandler.DenyInvite)
+	// s.Engine.GET("/invites", s.invitesHandler.ListInvites)
+
+	// Recommendations
 	s.Engine.POST("/recommendations/keywords", s.recommendationsHandler.ExtractKeywords)
 
 	s.Run()

--- a/main.go
+++ b/main.go
@@ -46,18 +46,18 @@ func main() {
 	s.Engine.DELETE("/groups/:group_id", s.groupsHandler.DeleteGroup)
 	s.Engine.GET("/groups", s.groupsHandler.ListGroups)
 
-	// // Group Members
-	// s.Engine.GET("/groups/:group_id/members/:member_id", s.groupsHandler.GetGroupMember)
-	// s.Engine.PATCH("/groups/:group_id/members/:member_id", s.groupsHandler.UpdateGroupMember)
-	// s.Engine.DELETE("/groups/:group_id/members/:member_id", s.groupsHandler.RemoveGroupMember)
-	// s.Engine.GET("/groups/:group_id/members", s.groupsHandler.ListGroupMembers)
+	// Group Members
+	s.Engine.GET("/groups/:group_id/members/:member_id", s.groupsHandler.GetGroupMember)
+	s.Engine.PATCH("/groups/:group_id/members/:member_id", s.groupsHandler.UpdateGroupMember)
+	s.Engine.DELETE("/groups/:group_id/members/:member_id", s.groupsHandler.RemoveGroupMember)
+	s.Engine.GET("/groups/:group_id/members", s.groupsHandler.ListGroupMembers)
 
-	// // Group Notes
-	// s.Engine.POST("/groups/:group_id/notes", s.groupsHandler.AddGroupNote)
-	// s.Engine.GET("/groups/:group_id/notes/:note_id", s.groupsHandler.GetGroupNote)
-	// s.Engine.PATCH("/groups/:group_id/notes/:note_id", s.groupsHandler.UpdateGroupNote)
-	// s.Engine.DELETE("/groups/:group_id/notes/:note_id", s.groupsHandler.RemoveGroupNote)
-	// s.Engine.GET("/groups/:group_id/notes", s.groupsHandler.ListGroupNotes)
+	// Group Notes
+	s.Engine.POST("/groups/:group_id/notes", s.groupsHandler.AddGroupNote)
+	s.Engine.GET("/groups/:group_id/notes/:note_id", s.groupsHandler.GetGroupNote)
+	s.Engine.PATCH("/groups/:group_id/notes/:note_id", s.groupsHandler.UpdateGroupNote)
+	s.Engine.DELETE("/groups/:group_id/notes/:note_id", s.groupsHandler.RemoveGroupNote)
+	s.Engine.GET("/groups/:group_id/notes", s.groupsHandler.ListGroupNotes)
 
 	// // Invites
 	// s.Engine.POST("/invites", s.invitesHandler.SendInvite)

--- a/server.go
+++ b/server.go
@@ -125,12 +125,12 @@ func (s *server) initClientConn(address string) *grpc.ClientConn {
 func (s *server) initLogger() {
 	var err error
 	if *environment == envIsDev {
-		s.logger, err = zap.NewDevelopment(zap.WithCaller(false))
+		s.logger, err = zap.NewDevelopment(zap.WithCaller(false), zap.AddStacktrace(zap.PanicLevel))
 		if err != nil {
 			panic(err)
 		}
 	} else {
-		s.logger, err = zap.NewProduction(zap.WithCaller(false))
+		s.logger, err = zap.NewProduction(zap.WithCaller(false), zap.AddStacktrace(zap.PanicLevel))
 		if err != nil {
 			panic(err)
 		}

--- a/server.go
+++ b/server.go
@@ -23,6 +23,9 @@ type server struct {
 	groupsClient  accountsv1.GroupsAPIClient
 	groupsHandler *groupsHandler
 
+	invitesClient  accountsv1.InvitesAPIClient
+	invitesHandler *invitesHandler
+
 	recommendationsConn    *grpc.ClientConn
 	recommendationsClient  recommendationsv1.RecommendationsAPIClient
 	recommendationsHandler *recommendationsHandler
@@ -43,6 +46,11 @@ func (s *server) Init() {
 	s.groupsClient = accountsv1.NewGroupsAPIClient(s.accountsConn)
 	s.groupsHandler = &groupsHandler{
 		groupsClient: s.groupsClient,
+	}
+
+	s.invitesClient = accountsv1.NewInvitesAPIClient(s.accountsConn)
+	s.invitesHandler = &invitesHandler{
+		invitesClient: s.invitesClient,
 	}
 
 	s.recommendationsConn = s.initClientConn(*recommendationsServiceAddress)

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -13,6 +14,10 @@ import (
 var (
 	httpAuthorizationHeader = "Authorization"
 	grpcAuthorizationHeader = "authorization"
+)
+
+var (
+	ErrUnauthenticated = errors.New("unauthenticated")
 )
 
 var grpcCodeToHttpCode = map[codes.Code]int{
@@ -55,4 +60,12 @@ func writeError(c *gin.Context, code int, err error) {
 		return
 	}
 	c.JSON(code, httpError{Error: err.Error()})
+}
+
+func authenticate(c *gin.Context) (string, error) {
+	bearer := c.GetHeader(httpAuthorizationHeader)
+	if bearer == "" {
+		return "", ErrUnauthenticated
+	}
+	return bearer, nil
 }

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"google.golang.org/grpc/codes"
@@ -68,4 +69,12 @@ func authenticate(c *gin.Context) (string, error) {
 		return "", ErrUnauthenticated
 	}
 	return bearer, nil
+}
+
+func queryAsInt32OrDefault(c *gin.Context, key string, def int32) int32 {
+	val, err := strconv.ParseInt(c.Query(key), 10, 32)
+	if err != nil {
+		return def
+	}
+	return int32(val)
 }


### PR DESCRIPTION
#### Description

Implementation of the HTTP endpoints with regards to the changes that were made to the `protorepo` for the Fast-Forward sprint. Check #13 for info.

Fixes #13.

#### Changelog

- [DOCS] Add documentation for all new and updated endpoints.
- [ENHANCEMENT] Add `/groups/:group_id/members` endpoints.
- [ENHANCEMENT] Add `/groups/:group_id/notes` endpoints.
- [ENHANCEMENT] Add `/invites` endpoints.
