### PR TITLE
Implemented in `/notes` the Notes and Blocks calling urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "protorepo"]
 	path = protorepo
 	url = git@github.com:noted-eip/protorepo.git
+	branch = main

--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ You can then build the project using the go toolchain.
 | `API_GATEWAY_PORT`                         | `--port`                         | `3000`                 | The port the application shall listen on.        |
 | `API_GATEWAY_ENV`                          | `--env`                          | `production`           | Either `production` or `development`.            |
 | `API_GATEWAY_ACCOUNTS_SERVICE_ADDR`        | `--accounts-service-addr`        | `accounts:3000`        | The address of the gRPC accounts service.        |
+| `API_GATEWAY_NOTES_SERVICE_ADDR` | `--notes-service-addr` | 
+`notes:3000` | The address of the gRPC notes service. |
 | `API_GATEWAY_RECOMMENDATIONS_SERVICE_ADDR` | `--recommendations-service-addr` | `recommendations:3000` | The address of the gRPC recommendations service. |

--- a/main.go
+++ b/main.go
@@ -72,13 +72,13 @@ func main() {
 	s.Engine.POST("/notes", s.notesHandler.CreateNote)
 	s.Engine.PATCH("/notes/:note_id", s.notesHandler.UpdateNote)
 	s.Engine.DELETE("/notes/:note_id", s.notesHandler.DeleteNote)
-	s.Engine.GET("/notes/:author_id", s.notesHandler.ListNotes)
-	s.Engine.GET("/notes/:note_id/export", s.notesHandler.ExportNote)
+	s.Engine.GET("/notes/?author_id=", s.notesHandler.ListNotes)
+	s.Engine.GET("/notes/:note_id/export/?format=", s.notesHandler.ExportNote)
 
 	// Blocks
 	s.Engine.POST("/notes/:note_id/blocks", s.notesHandler.InsertBlock)
-	s.Engine.PATCH("/notes/blocks/:block_id", s.notesHandler.UpdateBlock)
-	s.Engine.DELETE("/notes/blocks/:block_id", s.notesHandler.DeleteBlock)
+	s.Engine.PATCH("/notes/:note_id/blocks/:block_id", s.notesHandler.UpdateBlock)
+	s.Engine.DELETE("/notes/:note_id/blocks/:block_id", s.notesHandler.DeleteBlock)
 
 	// Recommendations
 	s.Engine.POST("/recommendations/keywords", s.recommendationsHandler.ExtractKeywords)

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ var (
 	port                          = app.Flag("port", "http api port").Default("3000").Int16()
 	environment                   = app.Flag("env", "production or development").Default(envIsProd).Enum(envIsProd, envIsDev)
 	accountsServiceAddress        = app.Flag("accounts-service-addr", "the grpc address of the accounts service").Default("accounts:3000").String()
+	notesServiceAddress           = app.Flag("notes-service-addr", "the grpc address of the notes service").Default("notes:3000").String()
 	recommendationsServiceAddress = app.Flag("recommendations-service-addr", "the grpc address of the recommendations service").Default("recommendations:3000").String()
 )
 
@@ -65,6 +66,19 @@ func main() {
 	s.Engine.POST("/invites/:invite_id/accept", s.invitesHandler.AcceptInvite)
 	s.Engine.POST("/invites/:invite_id/deny", s.invitesHandler.DenyInvite)
 	s.Engine.GET("/invites", s.invitesHandler.ListInvites)
+
+	// Notes
+	s.Engine.GET("/notes/:note_id", s.notesHandler.GetNote)
+	s.Engine.POST("/notes", s.notesHandler.CreateNote)
+	s.Engine.PATCH("/notes/:note_id", s.notesHandler.UpdateNote)
+	s.Engine.DELETE("/notes/:note_id", s.notesHandler.DeleteNote)
+	s.Engine.GET("/notes/:author_id", s.notesHandler.ListNotes)
+	s.Engine.GET("/notes/:note_id/export", s.notesHandler.ExportNote)
+
+	// Blocks
+	s.Engine.POST("/notes/:note_id/blocks", s.notesHandler.InsertBlock)
+	s.Engine.PATCH("/notes/blocks/:block_id", s.notesHandler.UpdateBlock)
+	s.Engine.DELETE("/notes/blocks/:block_id", s.notesHandler.DeleteBlock)
 
 	// Recommendations
 	s.Engine.POST("/recommendations/keywords", s.recommendationsHandler.ExtractKeywords)

--- a/notes.go
+++ b/notes.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	notesv1 "api-gateway/protorepo/noted/notes/v1"
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type notesHandler struct {
+	notesClient notesv1.NotesAPIClient
+}
+
+func (h *notesHandler) CreateNote(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &notesv1.CreateNoteRequest{}
+	if err := c.ShouldBindJSON(body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	res, err := h.notesClient.CreateNote(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *notesHandler) GetNote(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &notesv1.GetNoteRequest{
+		Id: c.Param("note_id"),
+	}
+
+	res, err := h.notesClient.GetNote(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *notesHandler) UpdateNote(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &notesv1.UpdateNoteRequest{}
+	if err := c.ShouldBindJSON(body); err != nil {
+		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+		return
+	}
+	body.Id = c.Param("note_id")
+
+	res, err := h.notesClient.UpdateNote(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *notesHandler) DeleteNote(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &notesv1.DeleteNoteRequest{
+		Id: c.Param("note_id"),
+	}
+
+	res, err := h.notesClient.DeleteNote(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *notesHandler) ListNotes(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &notesv1.ListNotesRequest{
+		AuthorId: c.Param("author_id"),
+	}
+
+	res, err := h.notesClient.ListNotes(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *notesHandler) ExportNote(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &notesv1.ExportNoteRequest{}
+	if err := c.ShouldBindJSON(body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
+		return
+	}
+	body.NoteId = c.Param("note_id")
+
+	res, err := h.notesClient.ExportNote(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *notesHandler) InsertBlock(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &notesv1.InsertBlockRequest{}
+	if err := c.ShouldBindJSON(body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
+		return
+	}
+	body.NoteId = c.Param("note_id")
+
+	res, err := h.notesClient.InsertBlock(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *notesHandler) UpdateBlock(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &notesv1.UpdateBlockRequest{}
+	if err := c.ShouldBindJSON(body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
+		return
+	}
+	body.Id = c.Param("block_id")
+
+	res, err := h.notesClient.UpdateBlock(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *notesHandler) DeleteBlock(c *gin.Context) {
+	bearer, err := authenticate(c)
+	if err != nil {
+		writeError(c, http.StatusUnauthorized, err)
+		return
+	}
+
+	body := &notesv1.DeleteBlockRequest{
+		Id: c.Param("block_id"),
+	}
+
+	res, err := h.notesClient.DeleteBlock(contextWithGrpcBearer(context.Background(), bearer), body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}

--- a/notes.go
+++ b/notes.go
@@ -3,6 +3,7 @@ package main
 import (
 	notesv1 "api-gateway/protorepo/noted/notes/v1"
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -130,8 +131,15 @@ func (h *notesHandler) ExportNote(c *gin.Context) {
 		"pdf": notesv1.NoteExportFormat_NOTE_EXPORT_FORMAT_PDF,
 	}
 
+	format, ok := formatMap[c.Query("format")]
+	if !ok {
+		err := errors.New("unknow export format")
+		writeError(c, http.StatusBadRequest, err)
+		return
+	}
+
 	body := &notesv1.ExportNoteRequest{
-		ExportFormat: notesv1.NoteExportFormat(formatMap[c.Query("format")]),
+		ExportFormat: notesv1.NoteExportFormat(format),
 	}
 	body.NoteId = c.Param("note_id")
 

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	accountsv1 "api-gateway/protorepo/noted/accounts/v1"
+	notesv1 "api-gateway/protorepo/noted/notes/v1"
 	recommendationsv1 "api-gateway/protorepo/noted/recommendations/v1"
 	"net/http"
 
@@ -16,6 +17,7 @@ import (
 
 type server struct {
 	accountsConn *grpc.ClientConn
+	notesConn    *grpc.ClientConn
 
 	accountsClient  accountsv1.AccountsAPIClient
 	accountsHandler *accountsHandler
@@ -25,6 +27,9 @@ type server struct {
 
 	invitesClient  accountsv1.InvitesAPIClient
 	invitesHandler *invitesHandler
+
+	notesClient  notesv1.NotesAPIClient
+	notesHandler *notesHandler
 
 	recommendationsConn    *grpc.ClientConn
 	recommendationsClient  recommendationsv1.RecommendationsAPIClient
@@ -51,6 +56,12 @@ func (s *server) Init() {
 	s.invitesClient = accountsv1.NewInvitesAPIClient(s.accountsConn)
 	s.invitesHandler = &invitesHandler{
 		invitesClient: s.invitesClient,
+	}
+
+	s.notesConn = s.initClientConn(*notesServiceAddress)
+	s.notesClient = notesv1.NewNotesAPIClient(s.notesConn)
+	s.notesHandler = &notesHandler{
+		notesClient: s.notesClient,
 	}
 
 	s.recommendationsConn = s.initClientConn(*recommendationsServiceAddress)


### PR DESCRIPTION
#### Description

Create a client of `NotesAPIClient` in server.go and the default adress in main.go called `notesServiceAddress`.
And the methods to call the clients endpoints in `notes.go` by the `/notes` url prefix.

#### Changelog

Implementation of methods to call by their url listed bellow :
- GetNote by "/notes/:note_id"
- CreateNote by "/notes"
- UpdateNote by "/notes/:note_id"
- DeleteNote by "/notes/:note_id"
- ListNotes by "/notes/:author_id"
- ExportNote by "/notes/:note_id/export"
- InsertBlock by "/notes/:note_id/blocks"
- UpdateBlock by "/notes/blocks/:block_id"
- DeleteBlock by "/notes/blocks/:block_id"