### PR TITLE
Change conversion JSON to GRPC & update documentation

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -14,8 +14,8 @@ type accountsHandler struct {
 
 func (h *accountsHandler) CreateAccount(c *gin.Context) {
 	body := &accountsv1.CreateAccountRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
@@ -77,8 +77,8 @@ func (h *accountsHandler) UpdateAccount(c *gin.Context) {
 	}
 
 	body := &accountsv1.UpdateAccountRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 	body.Account.Id = c.Param("account_id")
@@ -114,8 +114,8 @@ func (h *accountsHandler) DeleteAccount(c *gin.Context) {
 
 func (h *accountsHandler) Authenticate(c *gin.Context) {
 	body := &accountsv1.AuthenticateRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 

--- a/accounts.go
+++ b/accounts.go
@@ -14,8 +14,8 @@ type accountsHandler struct {
 
 func (h *accountsHandler) CreateAccount(c *gin.Context) {
 	body := &accountsv1.CreateAccountRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		writeError(c, http.StatusBadRequest, err)
+	if err := convertJsonToProto(c, body); err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -77,8 +77,8 @@ func (h *accountsHandler) UpdateAccount(c *gin.Context) {
 	}
 
 	body := &accountsv1.UpdateAccountRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+	if err := convertJsonToProto(c, body); err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 	body.Account.Id = c.Param("account_id")
@@ -114,8 +114,8 @@ func (h *accountsHandler) DeleteAccount(c *gin.Context) {
 
 func (h *accountsHandler) Authenticate(c *gin.Context) {
 	body := &accountsv1.AuthenticateRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		writeError(c, http.StatusBadRequest, err)
+	if err := convertJsonToProto(c, body); err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ This document describes all the endpoints of the Noted API gateway and their exp
       - [Get Note](#get-note)
       - [Update Note](#update-note)
       - [Delete Note](#delete-note)
-      - [List Notes](#list-notes)
+    - [List Notes](#list-notes)
       - [Export Note](#export-note)
     - [Blocks](#blocks)
       - [Insert Block](#insert-block)
@@ -136,7 +136,7 @@ This API enforces authorization. For example, you cannot modify a group you're n
     "account": {
         "name": "string",
     },
-    "update_mask": ["name"]
+    "update_mask": "name"
 }
 ```
 
@@ -281,7 +281,7 @@ This API enforces authorization. For example, you cannot modify a group you're n
         "name": "string",
         "description": "string",
     },
-    "update_mask": ["name", "description"]
+    "update_mask": "name,description"
 }
 ```
 
@@ -381,8 +381,7 @@ This API enforces authorization. For example, you cannot modify a group you're n
     "member": {
         "role": "string",
     },
-    "update_mask": ["role"]
-}
+    "update_mask": "role",
 ```
 
 **Response:**
@@ -518,7 +517,7 @@ This API enforces authorization. For example, you cannot modify a group you're n
         "title": "string",
         "folder_id": "string"
     },
-    "update_mask": ["title", "folder_id"]
+    "update_mask": "title,folder_id"
 }
 ```
 
@@ -700,7 +699,7 @@ This API enforces authorization. For example, you cannot modify a group you're n
 
 #### Create Note
 
-**Description:** Create a note with or without blocks depeding of you request. Must be logged with any role (user or admin).
+**Description:** Create a note.
 
 **Endpoint:** `POST /notes`
 
@@ -710,16 +709,10 @@ This API enforces authorization. For example, you cannot modify a group you're n
 ```json
 {
     "note": {
-        "author_id": "string",
         "title": "string",
         "blocks": [
             {
-                "type": 1,
-                "heading": "string"
-            },
-            {
-                "type": 4,
-                "paragraph": "string"
+                "type": "string"
             }
         ]
     }
@@ -736,13 +729,7 @@ This API enforces authorization. For example, you cannot modify a group you're n
         "blocks": [
             {
                 "id": "string",
-                "type": 1,
-                "heading": "string"
-            },
-            {
-                "id": "string",
-                "type": 4,
-                "paragraph": "string"
+                "type": "string"
             }
         ]
     }
@@ -751,7 +738,7 @@ This API enforces authorization. For example, you cannot modify a group you're n
 
 #### Get Note
 
-**Description:** Return a note with blocks and their id, the blocks are sorted by index. it also return the creation and modification date of the note. Must be in the group where the note belongs to, or the owner of the note.
+**Description:** Get a note and its blocks. Must be author or group member.
 
 **Endpoint:** `GET /notes/:note_id`
 
@@ -770,30 +757,18 @@ This API enforces authorization. For example, you cannot modify a group you're n
         "blocks": [
             {
                 "id": "string",
-                "type": 1,
-                "heading": "string"
-            },
-            {
-                "id": "string",
-                "type": 4,
-                "paragraph": "string"
+                "type": "string"
             }
         ],
-        "created_at": {
-            "seconds": "string",
-            "nanos": 600000000
-        },
-        "modified_at": {
-            "seconds": "string",
-            "nanos": 600000000
-        }
+        "created_at": "string",
+        "modified_at": "string"
     }
 }
 ```
 
 #### Update Note
 
-**Description:** Modify a note with or without blocks depeding of you request. Must be the owner of the note.
+**Description:** Must be author.
 
 **Endpoint:** `PATCH /notes/:note_id`
 
@@ -801,6 +776,16 @@ This API enforces authorization. For example, you cannot modify a group you're n
 
 **Path:**
 - `note_id`: UUID of the note.
+
+**Body:**
+```json
+{
+    "note": {
+        "title": "string",
+    },
+    "update_mask": "title"
+}
+```
 
 **Response:**
 ```json
@@ -811,9 +796,9 @@ This API enforces authorization. For example, you cannot modify a group you're n
 
 #### Delete Note
 
-**Description:** Delete a note with it blocks. Must be the owner of the note.
+**Description:** Delete a note and its blocks. Must be the owner of the note.
 
-**Endpoint:** `DEL /notes/:note_id`
+**Endpoint:** `DELETE /notes/:note_id`
 
 **Tags:** `AuthRequired`
 
@@ -822,19 +807,17 @@ This API enforces authorization. For example, you cannot modify a group you're n
 
 **Response:** 
 ```json
-{
-
-}
+{}
 ```
 
 ### List Notes
 
-**Description:** List all notes from an author by authorId. The notes are returned without the blocks but with the creation and modification date. Must be the owner or a member of the note's group.
+**Description:** Must be the author or a group member. Does not return blocks.
 
-**Endpoint:** `GET /notes/?author_id=`
+**Endpoint:** `GET /notes`
 
 **Query:**
-- `author_id=<string>`: author of the notes you want to be listed.
+- `author_id=<string>`: Filter based on note author.
 
 **Response:**
 ```json
@@ -844,27 +827,8 @@ This API enforces authorization. For example, you cannot modify a group you're n
             "id": "string",
             "author_id": "string",
             "title": "string",
-            "created_at": {
-                "seconds": "string",
-                "nanos": 600000000
-            },
-            "modified_at": {
-                "seconds": "string",
-                "nanos": 600000000
-            }
-        },
-        {
-            "id": "string",
-            "author_id": "string",
-            "title": "string",
-            "created_at": {
-                "seconds": "string",
-                "nanos": 600000000
-            },
-            "modified_at": {
-                "seconds": "string",
-                "nanos": 600000000
-            }
+            "created_at": "string",
+            "modified_at": "string"
         }
     ]
 }
@@ -872,28 +836,23 @@ This API enforces authorization. For example, you cannot modify a group you're n
 
 #### Export Note
 
-**Description:** Return a dowloable file in pdf or markdown in base64 encoded of the string of bytes corresponding to the array of bytes. Must be the owner or a member of the note's group.
+**Description:** Return a dowloable file in pdf or markdown format. Must be author or group member.
 
-**Endpoint:** `GET /notes/:note_id/export/?format=`
+**Endpoint:** `GET /notes/:note_id/export`
 
 **Path:**
 - `note_id`: UUID of the note.
 
 **Query:**
-- `format=<string>`: format of the note to get ("1" for markdown file or "2" for pdf).
+- `format=<string>`: Format of the file (either "md" or "pdf").
 
-**Response:**
-```json
-{
-    "file": "string"
-}
-```
+**Response:** File Contents
 
 ### Blocks
 
 #### Insert Block
 
-**Description:** Insert a block related to a note by noteId. Must be the owner of the note.
+**Description:** Insert a block at index. Must be the owner of the note.
 
 **Endpoint:** `POST /notes/:note_id/blocks`
 
@@ -905,13 +864,10 @@ This API enforces authorization. For example, you cannot modify a group you're n
 **Body:**
 ```json
 {
-    "block": 
-    {
-        "type": 1,
-        "heading": "string"
+    "block": {
+        "type": "string"
     },
-    "index": 1,
-    "note_id": "string"
+    "index": "number",
 }
 ```
 
@@ -920,15 +876,14 @@ This API enforces authorization. For example, you cannot modify a group you're n
 {
     "block": {
         "id": "string",
-        "type": "TYPE_HEADING_1",
-        "heading": "string"
+        "type": "string"
     }
 }
 ```
 
 #### Update Block
 
-**Description:** Update a block related to a note by noteId, can also modify the index of the blocks (so the order of blocks in the note). Must be the owner of the note.
+**Description:** Modify the contents of a block. Must be the owner of the note.
 
 **Endpoint:** `PATCH /notes/:note_id/blocks/:block_id`
 
@@ -941,12 +896,9 @@ This API enforces authorization. For example, you cannot modify a group you're n
 **Body:**
 ```json
 {
-    "id": "string",
-    "index": 2,
-    "block": 
-    {
-        "type": 4,
-        "paragraph": "string"
+    "index": "number",
+    "block": {
+        "type": "string"
     }
 }
 ```
@@ -956,17 +908,16 @@ This API enforces authorization. For example, you cannot modify a group you're n
 {
     "block": {
         "id": "string",
-        "type": "TYPE_PARAGRAPH",
-        "paragraph": "string"
+        "type": "string"
     }
 }
 ```
 
 #### Delete Block
 
-**Description:** Delete a block. Must be the owner of the note.
+**Description:** Must be the owner of the note.
 
-**Endpoint:** `DEL /notes/:note_id/blocks/:block_id`
+**Endpoint:** `DELETE /notes/:note_id/blocks/:block_id`
 
 **Tags:** `AuthRequired`
 
@@ -976,7 +927,5 @@ This API enforces authorization. For example, you cannot modify a group you're n
 
 **Response:**
 ```json
-{
-
-}
+{}
 ```

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/gin-gonic/gin v1.7.7
 	google.golang.org/grpc v1.46.2
-	google.golang.org/protobuf v1.27.1
+	google.golang.org/protobuf v1.28.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/groups.go
+++ b/groups.go
@@ -20,8 +20,8 @@ func (h *groupsHandler) CreateGroup(c *gin.Context) {
 	}
 
 	body := &accountsv1.CreateGroupRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		writeError(c, http.StatusBadRequest, err)
+	if err := convertJsonToProto(c, body); err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -82,8 +82,8 @@ func (h *groupsHandler) UpdateGroup(c *gin.Context) {
 	}
 
 	body := &accountsv1.UpdateGroupRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+	if err := convertJsonToProto(c, body); err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -150,8 +150,8 @@ func (h *groupsHandler) UpdateGroupMember(c *gin.Context) {
 	body := &accountsv1.UpdateGroupMemberRequest{
 		Member: &accountsv1.GroupMember{},
 	}
-	if err := c.ShouldBindJSON(body); err != nil {
-		writeError(c, http.StatusBadRequest, err)
+	if err := convertJsonToProto(c, body); err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -218,8 +218,8 @@ func (h *groupsHandler) AddGroupNote(c *gin.Context) {
 	}
 
 	body := &accountsv1.AddGroupNoteRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		writeError(c, http.StatusBadRequest, err)
+	if err := convertJsonToProto(c, body); err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -265,8 +265,8 @@ func (h *groupsHandler) UpdateGroupNote(c *gin.Context) {
 	body := &accountsv1.UpdateGroupNoteRequest{
 		Note: &accountsv1.GroupNote{},
 	}
-	if err := c.ShouldBindJSON(body); err != nil {
-		writeError(c, http.StatusBadRequest, err)
+	if err := convertJsonToProto(c, body); err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/groups.go
+++ b/groups.go
@@ -20,8 +20,8 @@ func (h *groupsHandler) CreateGroup(c *gin.Context) {
 	}
 
 	body := &accountsv1.CreateGroupRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
@@ -31,7 +31,7 @@ func (h *groupsHandler) CreateGroup(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) GetGroup(c *gin.Context) {
@@ -51,7 +51,7 @@ func (h *groupsHandler) GetGroup(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) DeleteGroup(c *gin.Context) {
@@ -71,7 +71,7 @@ func (h *groupsHandler) DeleteGroup(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) UpdateGroup(c *gin.Context) {
@@ -82,8 +82,8 @@ func (h *groupsHandler) UpdateGroup(c *gin.Context) {
 	}
 
 	body := &accountsv1.UpdateGroupRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
@@ -94,7 +94,7 @@ func (h *groupsHandler) UpdateGroup(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) ListGroups(c *gin.Context) {
@@ -116,7 +116,7 @@ func (h *groupsHandler) ListGroups(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) GetGroupMember(c *gin.Context) {
@@ -137,7 +137,7 @@ func (h *groupsHandler) GetGroupMember(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) UpdateGroupMember(c *gin.Context) {
@@ -150,8 +150,8 @@ func (h *groupsHandler) UpdateGroupMember(c *gin.Context) {
 	body := &accountsv1.UpdateGroupMemberRequest{
 		Member: &accountsv1.GroupMember{},
 	}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
@@ -164,7 +164,7 @@ func (h *groupsHandler) UpdateGroupMember(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) RemoveGroupMember(c *gin.Context) {
@@ -185,7 +185,7 @@ func (h *groupsHandler) RemoveGroupMember(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) ListGroupMembers(c *gin.Context) {
@@ -207,7 +207,7 @@ func (h *groupsHandler) ListGroupMembers(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) AddGroupNote(c *gin.Context) {
@@ -218,8 +218,8 @@ func (h *groupsHandler) AddGroupNote(c *gin.Context) {
 	}
 
 	body := &accountsv1.AddGroupNoteRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
@@ -231,7 +231,7 @@ func (h *groupsHandler) AddGroupNote(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) GetGroupNote(c *gin.Context) {
@@ -252,7 +252,7 @@ func (h *groupsHandler) GetGroupNote(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) UpdateGroupNote(c *gin.Context) {
@@ -265,8 +265,8 @@ func (h *groupsHandler) UpdateGroupNote(c *gin.Context) {
 	body := &accountsv1.UpdateGroupNoteRequest{
 		Note: &accountsv1.GroupNote{},
 	}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
@@ -279,7 +279,7 @@ func (h *groupsHandler) UpdateGroupNote(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) RemoveGroupNote(c *gin.Context) {
@@ -300,7 +300,7 @@ func (h *groupsHandler) RemoveGroupNote(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *groupsHandler) ListGroupNotes(c *gin.Context) {
@@ -324,5 +324,5 @@ func (h *groupsHandler) ListGroupNotes(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }

--- a/invites.go
+++ b/invites.go
@@ -20,8 +20,8 @@ func (h *invitesHandler) SendInvite(c *gin.Context) {
 	}
 
 	body := &accountsv1.SendInviteRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		writeError(c, http.StatusBadRequest, err)
+	if err := convertJsonToProto(c, body); err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/invites.go
+++ b/invites.go
@@ -20,8 +20,8 @@ func (h *invitesHandler) SendInvite(c *gin.Context) {
 	}
 
 	body := &accountsv1.SendInviteRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
@@ -31,7 +31,7 @@ func (h *invitesHandler) SendInvite(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *invitesHandler) GetInvite(c *gin.Context) {
@@ -51,7 +51,7 @@ func (h *invitesHandler) GetInvite(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *invitesHandler) AcceptInvite(c *gin.Context) {
@@ -71,7 +71,7 @@ func (h *invitesHandler) AcceptInvite(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *invitesHandler) DenyInvite(c *gin.Context) {
@@ -91,7 +91,7 @@ func (h *invitesHandler) DenyInvite(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *invitesHandler) ListInvites(c *gin.Context) {
@@ -115,5 +115,5 @@ func (h *invitesHandler) ListInvites(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }

--- a/notes.go
+++ b/notes.go
@@ -21,8 +21,8 @@ func (h *notesHandler) CreateNote(c *gin.Context) {
 	}
 
 	body := &notesv1.CreateNoteRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 
@@ -32,7 +32,7 @@ func (h *notesHandler) CreateNote(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *notesHandler) GetNote(c *gin.Context) {
@@ -52,7 +52,7 @@ func (h *notesHandler) GetNote(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *notesHandler) UpdateNote(c *gin.Context) {
@@ -63,8 +63,8 @@ func (h *notesHandler) UpdateNote(c *gin.Context) {
 	}
 
 	body := &notesv1.UpdateNoteRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 	body.Id = c.Param("note_id")
@@ -75,7 +75,7 @@ func (h *notesHandler) UpdateNote(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *notesHandler) DeleteNote(c *gin.Context) {
@@ -95,7 +95,7 @@ func (h *notesHandler) DeleteNote(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *notesHandler) ListNotes(c *gin.Context) {
@@ -115,7 +115,7 @@ func (h *notesHandler) ListNotes(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *notesHandler) ExportNote(c *gin.Context) {
@@ -163,8 +163,8 @@ func (h *notesHandler) InsertBlock(c *gin.Context) {
 	}
 
 	body := &notesv1.InsertBlockRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 	body.NoteId = c.Param("note_id")
@@ -175,7 +175,7 @@ func (h *notesHandler) InsertBlock(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *notesHandler) UpdateBlock(c *gin.Context) {
@@ -186,8 +186,8 @@ func (h *notesHandler) UpdateBlock(c *gin.Context) {
 	}
 
 	body := &notesv1.UpdateBlockRequest{}
-	if err := convertJsonToProto(c, body); err != nil {
-		writeError(c, http.StatusInternalServerError, err)
+	if err := readRequestBody(c, body); err != nil {
+		writeError(c, http.StatusBadRequest, err)
 		return
 	}
 	body.Id = c.Param("block_id")
@@ -198,7 +198,7 @@ func (h *notesHandler) UpdateBlock(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }
 
 func (h *notesHandler) DeleteBlock(c *gin.Context) {
@@ -218,5 +218,5 @@ func (h *notesHandler) DeleteBlock(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
+	writeResponse(c, res)
 }

--- a/notes.go
+++ b/notes.go
@@ -125,10 +125,13 @@ func (h *notesHandler) ExportNote(c *gin.Context) {
 		return
 	}
 
-	formatMap := map[string]notesv1.NoteExportFormat{
-		"":    notesv1.NoteExportFormat_NOTE_EXPORT_FORMAT_INVALID,
-		"md":  notesv1.NoteExportFormat_NOTE_EXPORT_FORMAT_MARKDOWN,
-		"pdf": notesv1.NoteExportFormat_NOTE_EXPORT_FORMAT_PDF,
+	formatMap := map[string]struct {
+		Format      notesv1.NoteExportFormat
+		ContentType string
+	}{
+		"":    {Format: notesv1.NoteExportFormat_NOTE_EXPORT_FORMAT_INVALID, ContentType: ""},
+		"md":  {Format: notesv1.NoteExportFormat_NOTE_EXPORT_FORMAT_MARKDOWN, ContentType: "text/markdown; charset=UTF-8"},
+		"pdf": {Format: notesv1.NoteExportFormat_NOTE_EXPORT_FORMAT_PDF, ContentType: "application/pdf"},
 	}
 
 	format, ok := formatMap[c.Query("format")]
@@ -139,7 +142,7 @@ func (h *notesHandler) ExportNote(c *gin.Context) {
 	}
 
 	body := &notesv1.ExportNoteRequest{
-		ExportFormat: notesv1.NoteExportFormat(format),
+		ExportFormat: notesv1.NoteExportFormat(format.Format),
 	}
 	body.NoteId = c.Param("note_id")
 
@@ -149,7 +152,7 @@ func (h *notesHandler) ExportNote(c *gin.Context) {
 		return
 	}
 
-	c.Data(http.StatusOK, "File", res.File)
+	c.Data(http.StatusOK, format.ContentType, res.File)
 }
 
 func (h *notesHandler) InsertBlock(c *gin.Context) {

--- a/notes.go
+++ b/notes.go
@@ -4,7 +4,10 @@ import (
 	notesv1 "api-gateway/protorepo/noted/notes/v1"
 	"context"
 	"errors"
+	"io/ioutil"
 	"net/http"
+
+	protobuf "google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/gin-gonic/gin"
 )
@@ -20,12 +23,17 @@ func (h *notesHandler) CreateNote(c *gin.Context) {
 		return
 	}
 
-	//convert les types en uint32?
-	//c quoi le soucis avec les data?
-
 	body := &notesv1.CreateNoteRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		writeError(c, http.StatusBadRequest, err)
+
+	requestBody, err := ioutil.ReadAll(c.Request.Body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	protobuf.Unmarshal(requestBody, body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/notes.go
+++ b/notes.go
@@ -4,10 +4,7 @@ import (
 	notesv1 "api-gateway/protorepo/noted/notes/v1"
 	"context"
 	"errors"
-	"io/ioutil"
 	"net/http"
-
-	protobuf "google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/gin-gonic/gin"
 )
@@ -24,15 +21,7 @@ func (h *notesHandler) CreateNote(c *gin.Context) {
 	}
 
 	body := &notesv1.CreateNoteRequest{}
-
-	requestBody, err := ioutil.ReadAll(c.Request.Body)
-	if err != nil {
-		writeError(c, http.StatusInternalServerError, err)
-		return
-	}
-
-	protobuf.Unmarshal(requestBody, body)
-	if err != nil {
+	if err := convertJsonToProto(c, body); err != nil {
 		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
@@ -74,15 +63,7 @@ func (h *notesHandler) UpdateNote(c *gin.Context) {
 	}
 
 	body := &notesv1.UpdateNoteRequest{}
-
-	requestBody, err := ioutil.ReadAll(c.Request.Body)
-	if err != nil {
-		writeError(c, http.StatusInternalServerError, err)
-		return
-	}
-
-	protobuf.Unmarshal(requestBody, body)
-	if err != nil {
+	if err := convertJsonToProto(c, body); err != nil {
 		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
@@ -179,14 +160,7 @@ func (h *notesHandler) InsertBlock(c *gin.Context) {
 	}
 
 	body := &notesv1.InsertBlockRequest{}
-	requestBody, err := ioutil.ReadAll(c.Request.Body)
-	if err != nil {
-		writeError(c, http.StatusInternalServerError, err)
-		return
-	}
-
-	protobuf.Unmarshal(requestBody, body)
-	if err != nil {
+	if err := convertJsonToProto(c, body); err != nil {
 		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
@@ -209,14 +183,7 @@ func (h *notesHandler) UpdateBlock(c *gin.Context) {
 	}
 
 	body := &notesv1.UpdateBlockRequest{}
-	requestBody, err := ioutil.ReadAll(c.Request.Body)
-	if err != nil {
-		writeError(c, http.StatusInternalServerError, err)
-		return
-	}
-
-	protobuf.Unmarshal(requestBody, body)
-	if err != nil {
+	if err := convertJsonToProto(c, body); err != nil {
 		writeError(c, http.StatusInternalServerError, err)
 		return
 	}

--- a/notes.go
+++ b/notes.go
@@ -74,8 +74,16 @@ func (h *notesHandler) UpdateNote(c *gin.Context) {
 	}
 
 	body := &notesv1.UpdateNoteRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		c.JSON(http.StatusOK, httpError{Error: err.Error()})
+
+	requestBody, err := ioutil.ReadAll(c.Request.Body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	protobuf.Unmarshal(requestBody, body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 	body.Id = c.Param("note_id")
@@ -171,8 +179,15 @@ func (h *notesHandler) InsertBlock(c *gin.Context) {
 	}
 
 	body := &notesv1.InsertBlockRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		writeError(c, http.StatusBadRequest, err)
+	requestBody, err := ioutil.ReadAll(c.Request.Body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	protobuf.Unmarshal(requestBody, body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 	body.NoteId = c.Param("note_id")
@@ -194,8 +209,15 @@ func (h *notesHandler) UpdateBlock(c *gin.Context) {
 	}
 
 	body := &notesv1.UpdateBlockRequest{}
-	if err := c.ShouldBindJSON(body); err != nil {
-		writeError(c, http.StatusBadRequest, err)
+	requestBody, err := ioutil.ReadAll(c.Request.Body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	protobuf.Unmarshal(requestBody, body)
+	if err != nil {
+		writeError(c, http.StatusInternalServerError, err)
 		return
 	}
 	body.Id = c.Param("block_id")

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -10,6 +11,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 var (
@@ -77,4 +80,16 @@ func queryAsInt32OrDefault(c *gin.Context, key string, def int32) int32 {
 		return def
 	}
 	return int32(val)
+}
+
+func convertJsonToProto(c *gin.Context, message protoreflect.ProtoMessage) error {
+	requestBody, err := ioutil.ReadAll(c.Request.Body)
+	if err != nil {
+		return err
+	}
+	err = protojson.Unmarshal(requestBody, message)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
#### Description

The conversion of json into oneof wasn't working. So we wasn't able to create block with data inside.
Fix the binding of json body messages into proto message, especialy for oneof field which wasn't working.

#### Changelog

Instead of `ShouldBindJSON` we use `ReadAll` to convert the json into bytes[] and `Unmarshall` (from protobuf/encoding/protojson package) which convert the bytes[] into proto.message.

- [BUGFIX]
Nil pointer for Block.Data field fixed for :
- CreateNote
- UpdateNote
- InsertBlock
- UpdateBlock